### PR TITLE
searchUsersByTeam get 1k users insted of 10

### DIFF
--- a/server/services/store/sqlstore/user.go
+++ b/server/services/store/sqlstore/user.go
@@ -225,7 +225,7 @@ func (s *SQLStore) getUsersByTeam(db sq.BaseRunner, _ string, _ string, _, _ boo
 }
 
 func (s *SQLStore) searchUsersByTeam(db sq.BaseRunner, _ string, searchQuery string, _ string, _, _, _ bool) ([]*model.User, error) {
-	users, err := s.getUsersByCondition(db, &sq.Like{"username": "%" + searchQuery + "%"}, 10)
+	users, err := s.getUsersByCondition(db, &sq.Like{"username": "%" + searchQuery + "%"}, 1000)
 	if model.IsErrNotFound(err) {
 		return []*model.User{}, nil
 	}


### PR DESCRIPTION
#### Summary
Im Share Board werden in der User-Suche nun alle (1k) User als Vorschlagsliste angezeigt:
![image](https://github.com/Hetzendorfer/focalboard_opportunity_mod/assets/46982704/6717e744-4279-4095-9aa1-a1592a58692e)
